### PR TITLE
Add idle disconnect and fix voice move stutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ Below is a screenshot demonstrating the MusicBot’s UI with button controls:
 
 ## Features
 
-- **Play music** from various sources (e.g., YouTube)  
-- **Queue management** for multiple songs  
-- **Playback controls** (play, pause, skip, stop)  
-- **Button-based interactions** for users who prefer a graphical interface  
-- **Command-based interface** for users who prefer text commands  
-- **Easy configuration** through environment variables or a config file  
+- **Play music** from various sources (e.g., YouTube)
+- **Queue management** for multiple songs
+- **Playback controls** (play, pause, skip, stop)
+- **Button-based interactions** for users who prefer a graphical interface
+- **Command-based interface** for users who prefer text commands
+- **Easy configuration** through environment variables or a config file
+- **Works across multiple guilds** with isolated queues
+- **Auto disconnect** when idle (default 2 minutes)
 
 ## Button-Based Usage
 

--- a/commands/music_commands.py
+++ b/commands/music_commands.py
@@ -286,7 +286,10 @@ async def _play_next_song(guild_id, client, queue_manager, player_manager, data_
             client.playback_modes[guild_id] = PlaybackMode.NORMAL
 
             # Schedule disconnect after delay
-            disconnect_task = asyncio.create_task(_disconnect_after_delay(guild_id, player_manager, 300))
+            from config import IDLE_DISCONNECT_DELAY
+            disconnect_task = asyncio.create_task(
+                _disconnect_after_delay(guild_id, player_manager, IDLE_DISCONNECT_DELAY)
+            )
             player_manager.add_task(guild_id, 'disconnect_task', disconnect_task)
 
         # Update UI

--- a/config.py
+++ b/config.py
@@ -42,3 +42,6 @@ SPOTIFY_CLIENT_SECRET = os.getenv('SPOTIFY_CLIENT_SECRET')
 # Logging Configuration
 LOG_LEVEL = "INFO"
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+# How long to stay connected when idle (in seconds)
+IDLE_DISCONNECT_DELAY = int(os.getenv("IDLE_DISCONNECT_DELAY", "120"))

--- a/managers/player_manager.py
+++ b/managers/player_manager.py
@@ -20,8 +20,15 @@ class PlayerManager:
 
             if voice_client:
                 if voice_client.channel != user_voice_channel:
-                    logger.info(f"Moving voice client in guild {guild_id} to {user_voice_channel}")
-                    await voice_client.move_to(user_voice_channel)
+                    if not voice_client.is_playing() and not voice_client.is_paused():
+                        logger.info(
+                            f"Moving voice client in guild {guild_id} to {user_voice_channel}"
+                        )
+                        await voice_client.move_to(user_voice_channel)
+                    else:
+                        logger.info(
+                            f"Voice client already playing in {voice_client.channel}; not moving"
+                        )
                 return voice_client
             else:
                 logger.info(f"Connecting to voice channel {user_voice_channel} in guild {guild_id}")


### PR DESCRIPTION
## Summary
- avoid moving the voice client while music is playing to prevent stutters
- add `IDLE_DISCONNECT_DELAY` configuration and use it for auto-disconnect
- document multi-guild support and auto-disconnect

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6859c9131ad08326a41103b42abb3785