### PR TITLE
Improve pm2 configuration and Web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,58 @@ If you prefer text commands, or if button-based interactions are unavailable for
    ```
 
    Once the bot is running, invite it to your server using the OAuth2 link provided in the Discord Developer Portal.
+
+## Web UI
+
+A basic Flask-based web interface is included. It provides a small web page for managing playback and JSON endpoints for viewing the queue and adding new songs.
+
+Start the bot normally, and the web UI will be available at `http://localhost:8080`.
+
+Open `http://localhost:8080/?guild_id=YOUR_GUILD_ID` in a browser to view the queue and add songs.
+
+- `GET /queue/<guild_id>` – Returns the current queue for the guild.
+- `POST /play` – JSON endpoint to add a song. Requires `guild_id` and `query` fields.
+
+You can customize the host and port using the `WEB_UI_HOST` and `WEB_UI_PORT` environment variables.
+
+### Running with pm2
+
+If you prefer to keep the bot running with [pm2](https://pm2.keymetrics.io/),
+create an `ecosystem.config.js` file like the following (adjust the paths as
+needed):
+
+```js
+module.exports = {
+  apps: [{
+    name: 'musicbot',
+    script: './bot.py',
+    interpreter: '/home/leo29798/musicbot-env/bin/python',
+    cwd: '/home/leo29798/MusicBot',
+    env: {
+      PYTHONUNBUFFERED: '1',
+      NODE_ENV: 'production',
+      WEB_UI_HOST: '0.0.0.0',
+      WEB_UI_PORT: '8080'
+    },
+    error_file: './logs/err.log',
+    out_file: './logs/out.log',
+    log_file: './logs/combined.log',
+    time: true,
+    autorestart: true,
+    watch: false,
+    max_memory_restart: '1G',
+    restart_delay: 3000, // Wait 3s before restart
+    max_restarts: 10,    // Limit restart attempts
+    min_uptime: '10s'    // Must stay up 10s to be considered successful
+  }]
+};
+```
+
+This sample sets `WEB_UI_HOST` and `WEB_UI_PORT` so you can change the address
+where the Web UI is served.
+
+Start the bot under pm2 with:
+
+```bash
+pm2 start ecosystem.config.js
+```

--- a/bot.py
+++ b/bot.py
@@ -150,6 +150,13 @@ def load_extensions():
 
 def main():
     load_extensions()
+    # Start optional web UI
+    try:
+        from web_ui import start_web_ui
+        start_web_ui()
+    except Exception as e:
+        logger.error(f'Failed to start web UI: {e}')
+
     token = TOKEN or os.getenv('DISCORD_TOKEN')
     if not token:
         raise RuntimeError('DISCORD_TOKEN is not set')

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  apps: [{
+    name: 'musicbot',
+    script: './bot.py',
+    interpreter: '/home/leo29798/musicbot-env/bin/python',
+    cwd: '/home/leo29798/MusicBot',
+    env: {
+      PYTHONUNBUFFERED: '1', // Better for real-time logging
+      NODE_ENV: 'production',
+      WEB_UI_HOST: '0.0.0.0',
+      WEB_UI_PORT: '8080'
+    },
+    error_file: './logs/err.log',
+    out_file: './logs/out.log',
+    log_file: './logs/combined.log',
+    time: true,
+    autorestart: true,
+    watch: false,
+    max_memory_restart: '1G',
+    restart_delay: 3000, // Wait 3s before restart
+    max_restarts: 10,    // Limit restart attempts
+    min_uptime: '10s'    // Must stay up 10s to be considered successful
+  }]
+};

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ yt-dlp
 python-dotenv
 requests
 ffmpeg
+Flask

--- a/web_ui/__init__.py
+++ b/web_ui/__init__.py
@@ -1,0 +1,3 @@
+from .app import start_web_ui
+
+__all__ = ["start_web_ui"]

--- a/web_ui/app.py
+++ b/web_ui/app.py
@@ -1,0 +1,123 @@
+import threading
+import asyncio
+import os
+from flask import Flask, request, jsonify, render_template_string
+
+app = Flask(__name__)
+
+
+INDEX_TEMPLATE = """
+<!doctype html>
+<title>MusicBot Web UI</title>
+<h1>MusicBot Web UI</h1>
+{% if guild_id %}
+  <p>Guild ID: {{ guild_id }}</p>
+  <h2>Queue</h2>
+  <ul>
+    {% for item in queue %}
+      <li>{{ loop.index }}. {{ item.title }}</li>
+    {% else %}
+      <li>No songs queued.</li>
+    {% endfor %}
+  </ul>
+{% else %}
+  <p>No guild_id specified.</p>
+{% endif %}
+
+<h2>Add Song</h2>
+<form method="post" action="/play_form">
+  <input type="text" name="guild_id" placeholder="Guild ID" value="{{ guild_id or '' }}">
+  <input type="text" name="query" placeholder="Song URL or search" required>
+  <button type="submit">Play</button>
+</form>
+"""
+
+
+def start_web_ui(host: str = "0.0.0.0", port: int = 8080):
+    """Start the web UI in a separate thread.
+
+    The ``WEB_UI_HOST`` and ``WEB_UI_PORT`` environment variables override the
+    provided ``host`` and ``port`` arguments so you can easily configure the
+    address in deployments (e.g. pm2).
+    """
+    host = os.getenv("WEB_UI_HOST", host)
+    port = int(os.getenv("WEB_UI_PORT", str(port)))
+    thread = threading.Thread(
+        target=lambda: app.run(host=host, port=port, debug=False, use_reloader=False),
+        daemon=True,
+    )
+    thread.start()
+
+
+@app.route("/")
+def index():
+    guild_id = request.args.get("guild_id")
+    queue = []
+    if guild_id:
+        from bot_state import queue_manager
+        queue = queue_manager.get_queue(str(guild_id))
+    return render_template_string(INDEX_TEMPLATE, guild_id=guild_id, queue=queue)
+
+
+@app.route('/queue/<int:guild_id>')
+def get_queue(guild_id):
+    from bot_state import queue_manager
+    queue = queue_manager.get_queue(str(guild_id))
+    return jsonify(queue)
+
+
+@app.route('/play', methods=['POST'])
+def play_song():
+    data = request.json or {}
+    result, status = play_song_view(data)
+    return jsonify(result), status
+
+
+@app.route('/play_form', methods=['POST'])
+def play_song_form():
+    guild_id = request.form.get('guild_id')
+    query = request.form.get('query')
+    data = {'guild_id': guild_id, 'query': query}
+    play_song_view(data)
+    from flask import redirect, url_for
+    return redirect(url_for('index', guild_id=guild_id))
+
+
+def play_song_view(data):
+    guild_id = data.get('guild_id')
+    query = data.get('query')
+    if guild_id is None or query is None:
+        return {'error': 'guild_id and query are required'}, 400
+
+    from bot_state import client, queue_manager, player_manager, data_manager
+    from commands.music_commands import process_play_request
+
+    guild = client.get_guild(int(guild_id))
+    if not guild:
+        return {'error': 'Invalid guild_id'}, 400
+
+    guild_id_str = str(guild_id)
+    channel_id = client.guilds_data.get(guild_id_str, {}).get('channel_id')
+    if not channel_id:
+        return {'error': 'Bot is not set up in this guild'}, 400
+
+    channel = client.get_channel(int(channel_id))
+    user = guild.me
+
+    coro = process_play_request(
+        user,
+        guild,
+        channel,
+        query,
+        client,
+        queue_manager,
+        player_manager,
+        data_manager,
+    )
+
+    future = asyncio.run_coroutine_threadsafe(coro, client.loop)
+    result = future.result()
+    return {'message': result}, 200
+
+
+


### PR DESCRIPTION
## Summary
- fix pm2 ecosystem snippet in README
- document how to open the new simple web UI
- add basic HTML page in the Flask web UI for queue and play form

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6861c9dae4e08326b3cd4302c5512a5d